### PR TITLE
Slight speed-up of permshap()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: kernelshap
 Title: Kernel SHAP
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre")),
     person("David", "Watson", , "david.s.watson11@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# kernelshap 0.4.1
+
+## Other changes
+
+- Slight speed-up of `permshap()` by saving calculations for the two special permutations of all 0 and all 1.
+- Consequently, the `m_exact` component in the output is reduced by 2.
+
 # kernelshap 0.4.0
 
 ## Major changes

--- a/packaging.R
+++ b/packaging.R
@@ -15,7 +15,7 @@ library(usethis)
 use_description(
   fields = list(
     Title = "Kernel SHAP",
-    Version = "0.4.0",
+    Version = "0.4.1",
     Description = "Efficient implementation of Kernel SHAP, see Lundberg and Lee (2017),
     and Covert and Lee (2021) <http://proceedings.mlr.press/v130/covert21a>.
     Furthermore, for up to 14 features, exact permutation SHAP values can be calculated.


### PR DESCRIPTION
This PR removes the workload from calculating v_z for the two special permutations v_0 and v_1