### PR TITLE
Remove special case of single means

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,6 @@
 
 - Slight speed-up of `permshap()` by saving calculations for the two special permutations of all 0 and all 1.
 - Consequently, the `m_exact` component in the output is reduced by 2.
-- Slight speed-up of `permshap()` by optimizing internal function `shapley_formula()`.
 - Slight speed-up of `kernelshap()` and `permshap()` for single-output predictions.
 
 # kernelshap 0.4.0

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,13 +9,11 @@
 #' @param w Optional case weights.
 #' @returns A (1 x ncol(x)) matrix of column means.
 wcolMeans <- function(x, w = NULL, ...) {
-  if (NCOL(x) == 1L && is.null(w)) {
-    return(as.matrix(mean(x)))
-  }
   if (!is.matrix(x)) {
     x <- as.matrix(x)
   }
-  rbind(if (is.null(w)) colMeans(x) else colSums(x * w) / sum(w))
+  out <- if (is.null(w)) colMeans(x) else colSums(x * w) / sum(w)
+  t.default(out)
 }
 
 #' All on-off Vectors


### PR DESCRIPTION
In the internal function `wcolMeans()`, the univariate case is handled via `mean()`, which is often slower than `colMeans()`. So this dispatch can be removed.