### PR TITLE
additive_shap matches permshap and kernelshap() for full background data only

### DIFF
--- a/R/additive_shap.R
+++ b/R/additive_shap.R
@@ -44,8 +44,14 @@
 #'   Sepal.Length ~ poly(Sepal.Width, 2) + log(Petal.Length) + log(Sepal.Width),
 #'   data = iris
 #' )
-#' s <- additive_shap(fit, head(iris))
-#' s
+#' s_add <- additive_shap(fit, head(iris))
+#' s_add
+#' 
+#' # Equals kernelshap()/permshap() when background data is full training data
+#' s_kernel <- kernelshap(
+#'  fit, head(iris[c("Sepal.Width", "Petal.Length")]), bg_X = iris
+#' )
+#' all.equal(s_add$S, s_kernel$S)
 additive_shap <- function(object, X, verbose = TRUE, ...) {
   stopifnot(
     inherits(object, c("lm", "glm", "gam", "bam", "Gam", "coxph", "survreg"))

--- a/R/additive_shap.R
+++ b/R/additive_shap.R
@@ -14,6 +14,10 @@
 #' a logic heavily inspired by `fastshap:::explain.lm(..., exact = TRUE)`.
 #' Models with interactions (specified via `:` or `*`), or with terms of
 #' multiple features like `log(x1/x2)` are not supported.
+#' 
+#' Note that the SHAP values obtained by [additive_shap()] are expected to
+#' match those of [permshap()] and [kernelshap()] as long as their background
+#' data equals the full training data (which is typically not feasible).
 #'
 #' @inheritParams kernelshap
 #' @param X Dataframe with rows to be explained. Will be used like

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The package contains two workhorses to calculate SHAP values for *any* model:
 - `kernelshap()`: Kernel SHAP algorithm of [2] and [3]. By default, exact Kernel SHAP is used for up to $p=8$ features, and an almost exact hybrid algorithm otherwise.
 
 Furthermore, the function `additive_shap()` produces SHAP values for additive models fitted via `lm()`, `glm()`, `mgcv::gam()`, `mgcv::bam()`, `gam::gam()`,
- `survival::coxph()`, or `survival::survreg()`. It is exponentially faster than `permshap()` and `kernelshap()`, with identical results.
+ `survival::coxph()`, or `survival::survreg()`. It is exponentially faster than `permshap()` and `kernelshap()`, with identical results when the background dataset of the latter equals the full training data.
 
 ### Kernel SHAP or permutation SHAP?
 

--- a/man/additive_shap.Rd
+++ b/man/additive_shap.Rd
@@ -62,6 +62,12 @@ fit <- lm(
   Sepal.Length ~ poly(Sepal.Width, 2) + log(Petal.Length) + log(Sepal.Width),
   data = iris
 )
-s <- additive_shap(fit, head(iris))
-s
+s_add <- additive_shap(fit, head(iris))
+s_add
+
+# Equals kernelshap()/permshap() when background data is full training data
+s_kernel <- kernelshap(
+ fit, head(iris[c("Sepal.Width", "Petal.Length")]), bg_X = iris
+)
+all.equal(s_add$S, s_kernel$S)
 }

--- a/man/additive_shap.Rd
+++ b/man/additive_shap.Rd
@@ -46,6 +46,10 @@ The SHAP values are extracted via \code{predict(object, newdata = X, type = "ter
 a logic heavily inspired by \code{fastshap:::explain.lm(..., exact = TRUE)}.
 Models with interactions (specified via \code{:} or \code{*}), or with terms of
 multiple features like \code{log(x1/x2)} are not supported.
+
+Note that the SHAP values obtained by \code{\link[=additive_shap]{additive_shap()}} are expected to
+match those of \code{\link[=permshap]{permshap()}} and \code{\link[=kernelshap]{kernelshap()}} as long as their background
+data equals the full training data (which is typically not feasible).
 }
 \examples{
 # MODEL ONE: Linear regression

--- a/tests/testthat/test-additive_shap.R
+++ b/tests/testthat/test-additive_shap.R
@@ -1,4 +1,4 @@
-test_that("simple additive formula gives same as permshap()", {
+test_that("simple additive formula gives same as permshap() if full training data is used as bg data", {
   form <- Sepal.Length ~ .
   fit_lm <- lm(form, data = iris)
   fit_glm <- glm(form, data = iris, family = quasipoisson)
@@ -17,7 +17,7 @@ test_that("simple additive formula gives same as permshap()", {
   expect_equal(s_add_glm$predictions, unname(predict(fit_glm, newdata = X)))
 })
 
-test_that("formula where feature appears in two terms gives same as permshap()", {
+test_that("formula where feature appears in two terms gives same as permshap() if full training data is used as bg data", {
   form <- Sepal.Length ~ log(Sepal.Width) + poly(Sepal.Width, 2) + Petal.Length
   fit_lm <- lm(form, data = iris)
   fit_glm <- glm(form, data = iris, family = quasipoisson)
@@ -36,7 +36,7 @@ test_that("formula where feature appears in two terms gives same as permshap()",
   expect_equal(s_add_glm$predictions, unname(predict(fit_glm, newdata = X)))
 })
 
-test_that("formula with complicated terms gives same as permshap()", {
+test_that("formula with complicated terms gives same as permshap() if full training data is used as bg data", {
   form <- Sepal.Length ~ 
     log(Sepal.Width) + Species + poly(Petal.Length, 2)
   


### PR DESCRIPTION
This is documented in the README, the function documentation as well as in the unit tests.