### PR TITLE
Remove factor predictions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^pkgdown/_pkgdown\.yml$
 ^\.github$
 ^revdep$
+^compare_with_python.R$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Imports: 
     foreach,
+    MASS,
     stats,
     utils
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,11 @@
 Package: kernelshap
 Title: Kernel SHAP
-Version: 0.5.1
+Version: 0.6.0
 Authors@R: c(
-    person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre")),
-    person("David", "Watson", , "david.s.watson11@gmail.com", role = "aut"),
+    person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-6148-5756")),
+    person("David", "Watson", , "david.s.watson11@gmail.com", role = "aut",
+           comment = c(ORCID = "0000-0001-9632-2159")),
     person("Przemyslaw", "Biecek", , "przemyslaw.biecek@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0001-8423-1823"))
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,15 @@
-# kernelshap 0.5.1
+# kernelshap 0.6.0
+
+This release is intended to be the last before stable version 1.0.0.
+
+## Major changes
+
+- Factor-valued predictions are not anymore supported.
 
 ## Maintenance
 
-- Fix CRAN note regarding unavailable link to `gam::gam()`.
+- Fix CRAN note about unavailable link to `gam::gam()`.
+- Added dependency to {MASS} for calculating Moore-Penrose generalized matrix inverse.
 
 # kernelshap 0.5.0
 

--- a/R/utils_kernelshap.R
+++ b/R/utils_kernelshap.R
@@ -88,36 +88,10 @@ kernelshap_one <- function(x, v1, object, pred_fun, feature_names, bg_w, exact, 
 # A: (p x p), b: (p x k), constraint: (1 x K)
 solver <- function(A, b, constraint) {
   p <- ncol(A)
-  Ainv <- ginv(A)
+  Ainv <- MASS::ginv(A)
   dimnames(Ainv) <- dimnames(A)
   s <- (matrix(colSums(Ainv %*% b), nrow = 1L) - constraint) / sum(Ainv)     #  (1 x K)
   Ainv %*% (b - s[rep.int(1L, p), , drop = FALSE])                           #  (p x K)
-}
-
-ginv <- function (X, tol = sqrt(.Machine$double.eps)) {
-  ##
-  ## Based on an original version in package MASS 7.3.56
-  ## (with permission)
-  ##
-  if (length(dim(X)) > 2L || !(is.numeric(X) || is.complex(X))) {
-    stop("'X' must be a numeric or complex matrix")
-  }
-  if (!is.matrix(X)) {
-    X <- as.matrix(X)
-  }
-  Xsvd <- svd(X)
-  if (is.complex(X)) {
-    Xsvd$u <- Conj(Xsvd$u)
-  }
-  Positive <- Xsvd$d > max(tol * Xsvd$d[1L], 0)
-  if (all(Positive)) {
-    Xsvd$v %*% (1 / Xsvd$d * t(Xsvd$u))
-  } else if (!any(Positive)) {
-    array(0, dim(X)[2L:1L])
-  } else {
-    Xsvd$v[, Positive, drop = FALSE] %*% 
-      ((1 / Xsvd$d[Positive]) * t(Xsvd$u[, Positive, drop = FALSE]))
-  }
 }
 
 # Draw m binary vectors z of length p with sum(z) distributed according 

--- a/packaging.R
+++ b/packaging.R
@@ -15,15 +15,15 @@ library(usethis)
 use_description(
   fields = list(
     Title = "Kernel SHAP",
-    Version = "0.5.1",
+    Version = "0.6.0",
     Description = "Efficient implementation of Kernel SHAP, see Lundberg and Lee (2017),
     and Covert and Lee (2021) <http://proceedings.mlr.press/v130/covert21a>.
     Furthermore, for up to 14 features, exact permutation SHAP values can be calculated.
     The package plays well together with meta-learning packages like 'tidymodels', 'caret' or 'mlr3'.
     Visualizations can be done using the R package 'shapviz'.",
     `Authors@R` = 
-    "c(person('Michael', family='Mayer', role=c('aut', 'cre'), email='mayermichael79@gmail.com'),
-       person('David', family='Watson', role='aut', email='david.s.watson11@gmail.com'),
+    "c(person('Michael', family='Mayer', role=c('aut', 'cre'), email='mayermichael79@gmail.com', comment=c(ORCID='0000-0002-6148-5756')),
+       person('David', family='Watson', role='aut', email='david.s.watson11@gmail.com', comment=c(ORCID='0000-0001-9632-2159')),
        person('Przemyslaw', family='Biecek', email='przemyslaw.biecek@gmail.com', role='ctb', comment=c(ORCID='0000-0001-8423-1823'))
       )",
     Depends = "R (>= 3.2.0)",

--- a/packaging.R
+++ b/packaging.R
@@ -32,9 +32,10 @@ use_description(
   roxygen = TRUE
 )
 
+use_package("foreach", "Imports")
+use_package("MASS", "Imports")
 use_package("stats", "Imports")
 use_package("utils", "Imports")
-use_package("foreach", "Imports")
 
 use_package("doFuture", "Suggests")
 

--- a/tests/testthat/test-kernelshap-multioutput.R
+++ b/tests/testthat/test-kernelshap-multioutput.R
@@ -86,17 +86,3 @@ test_that("Baseline equals weighted average prediction on background data", {
 test_that("SHAP + baseline = prediction works with case weights", {
   expect_equal(rowSums(sY$S[[2L]]) + sY$baseline[2L], predsY[5:10, 2L])
 })
-
-test_that("factor predictions work", {
-  pf <- function(m, X) factor(X[, "v1"], levels = 0:1, labels = c("zero", "one"))
-  X <- cbind(v1 = 0:1, v2 = 0)
-  out <- kernelshap(1, X = X, bg_X = X, pred_fun = pf, verbose = FALSE)
-  expect_equal(colnames(out$S$zero), c("v1", "v2"))
-  expect_equal(names(out$S), c("zero", "one"))
-  expect_equal(out$predictions, cbind(zero = 1:0, one = 0:1))
-  
-  # with weights
-  w <- rep(2, nrow(X))
-  out2 <- kernelshap(1, X = X, bg_X = X, bg_w = w, pred_fun = pf, verbose = FALSE)
-  expect_equal(out, out2)
-})

--- a/tests/testthat/test-kernelshap.R
+++ b/tests/testthat/test-kernelshap.R
@@ -238,4 +238,3 @@ test_that("kernelshap works for large p (hybrid case)", {
   expect_equal(rowSums(s$S) + s$baseline, unname(predict(fit, X[1L, ])))
 })
 
-

--- a/tests/testthat/test-permshap-multioutput.R
+++ b/tests/testthat/test-permshap-multioutput.R
@@ -75,16 +75,3 @@ test_that("SHAP + baseline = prediction works with case weights", {
   expect_equal(rowSums(sY$S[[2L]]) + sY$baseline[2L], predsY[5:10, 2L])
 })
 
-test_that("factor predictions work", {
-  pf <- function(m, X) factor(X[, "v1"], levels = 0:1, labels = c("zero", "one"))
-  X <- cbind(v1 = 0:1, v2 = 0)
-  out <- permshap(1, X = X, bg_X = X, pred_fun = pf, verbose = FALSE)
-  expect_equal(colnames(out$S$zero), c("v1", "v2"))
-  expect_equal(names(out$S), c("zero", "one"))
-  expect_equal(out$predictions, cbind(zero = 1:0, one = 0:1))
-  
-  # with weights
-  w <- rep(2, nrow(X))
-  out2 <- permshap(1, X = X, bg_X = X, bg_w = w, pred_fun = pf, verbose = FALSE)
-  expect_equal(out, out2)
-})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -60,27 +60,6 @@ test_that("rep_each() works", {
   expect_true(is.integer(rep_each(100, 100)))
 })
 
-test_that("fdummy() works", {
-  x <- c("A", "A", "C", "D")
-  mm <- matrix(model.matrix(~ x + 0), ncol = 3, dimnames = list(NULL, c("A", "C", "D")))
-  expect_equal(fdummy(x), mm)
-})
-
-test_that("fdummy() works for singletons", {
-  x <- c("A")
-  expect_equal(fdummy(x), cbind(A = 1))
-  expect_true(is.matrix(fdummy(x)))
-})
-
-test_that("fdummy() respects factor level order", {
-  x1 <- factor(c("A", "A", "C", "D"))
-  x2 <- factor(x1, levels = rev(levels(x1)))
-  d1 <- fdummy(x1)
-  d2 <- fdummy(x2)
-  expect_equal(d1, d2[, colnames(d1)])
-  expect_equal(colnames(d1), rev(colnames(d2)))
-})
-
 test_that("wrowmean_vector() works for 1D matrices", {
   x2 <- cbind(a = 6:1)
   out2 <- wrowmean_vector(x2, ngroups = 2L)
@@ -103,10 +82,3 @@ test_that("wrowmean_vector() works for 1D matrices", {
   expect_equal(out2, cbind(a = c(a, b)))
 })
 
-test_that("rowmean_factor() works for factor input", {
-  x <- factor(c("C", "A", "C", "C", "A", "A"))
-  out <- rowmean_factor(x, ngroups = 2L)
-  
-  expect_true(is.matrix(out))
-  expect_equal(out, cbind(A = c(1/3, 2/3), C = c(2/3, 1/3)))
-})


### PR DESCRIPTION
This PR 

- removes the possibility to work with factor-valued predictions,
- adds ORCID for Michael and David,
- replaces ginv() by MASS::ginv(), adding MASS again as dependency.