### PR TITLE
Add note on parallel warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: kernelshap
 Title: Kernel SHAP
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: c(
     person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0007-2540-9629")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# kernelshap 0.8.1
+
+### Documentation
+
+- `kernelshap()` and `permshap()` currently yield a warning on random seed handling in
+  parallel mode, thanks [#152](https://github.com/ModelOriented/kernelshap/issues/163)
+  for reporting. We have added a note in the function documentation that this warning
+  can be ignored.
+
 # kernelshap 0.8.0
 
 ### Major improvement

--- a/R/kernelshap.R
+++ b/R/kernelshap.R
@@ -125,6 +125,8 @@
 #'   Ideally, this is `NULL` (default). Only relevant if `parallel = TRUE`.
 #'   Example on Windows: if `object` is a GAM fitted with package 'mgcv',
 #'   then one might need to set `parallel_args = list(.packages = "mgcv")`.
+#'   The warning "unexpectedly generated random numbers" can be ignored because
+#'   sharing seeds across rows of `X` it is not a problem.
 #' @param verbose Set to `FALSE` to suppress messages and the progress bar.
 #' @param survival Should cumulative hazards ("chf", default) or survival
 #'   probabilities ("prob") per time be predicted? Only in `ranger()` survival models.

--- a/man/kernelshap.Rd
+++ b/man/kernelshap.Rd
@@ -123,7 +123,9 @@ see README for an example. Parallelization automatically disables the progress b
 \item{parallel_args}{Named list of arguments passed to \code{\link[foreach:foreach]{foreach::foreach()}}.
 Ideally, this is \code{NULL} (default). Only relevant if \code{parallel = TRUE}.
 Example on Windows: if \code{object} is a GAM fitted with package 'mgcv',
-then one might need to set \code{parallel_args = list(.packages = "mgcv")}.}
+then one might need to set \code{parallel_args = list(.packages = "mgcv")}.
+The warning "unexpectedly generated random numbers" can be ignored because
+sharing seeds across rows of \code{X} it is not a problem.}
 
 \item{verbose}{Set to \code{FALSE} to suppress messages and the progress bar.}
 

--- a/man/permshap.Rd
+++ b/man/permshap.Rd
@@ -102,7 +102,9 @@ see README for an example. Parallelization automatically disables the progress b
 \item{parallel_args}{Named list of arguments passed to \code{\link[foreach:foreach]{foreach::foreach()}}.
 Ideally, this is \code{NULL} (default). Only relevant if \code{parallel = TRUE}.
 Example on Windows: if \code{object} is a GAM fitted with package 'mgcv',
-then one might need to set \code{parallel_args = list(.packages = "mgcv")}.}
+then one might need to set \code{parallel_args = list(.packages = "mgcv")}.
+The warning "unexpectedly generated random numbers" can be ignored because
+sharing seeds across rows of \code{X} it is not a problem.}
 
 \item{verbose}{Set to \code{FALSE} to suppress messages and the progress bar.}
 

--- a/packaging.R
+++ b/packaging.R
@@ -15,7 +15,7 @@ library(usethis)
 use_description(
   fields = list(
     Title = "Kernel SHAP",
-    Version = "0.8.0",
+    Version = "0.8.1",
     Description = "Efficient implementation of Kernel SHAP
     (Lundberg and Lee, 2017, <doi:10.48550/arXiv.1705.07874>)
     permutation SHAP, and additive SHAP for model interpretability.


### PR DESCRIPTION
This PR adds a hint to the docstring of `kernelshap()` and `permshap()` that the warning about random seeds in parallel mode can safely be ignored, thanks Implements https://github.com/ModelOriented/kernelshap/issues/163 for reporting.