### PR TITLE
Avoid replication of x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,15 @@
 # kernelshap 0.8.1
 
-### Performance improvements
+### API
 
-- `permshap(, exact = TRUE)` is slightly faster by pre-calculating more 
+- The argument `feature_names` can now also be used with matrix input ([#166](https://github.com/ModelOriented/kernelshap/pull/166)).
+
+### Speed and memory improvements
+
+- `permshap()` and `kernelshap()` require about 10% less memory ([#166](https://github.com/ModelOriented/kernelshap/pull/166)).
+- `permshap()` and `kernelshap()` are faster for data.frame input, 
+  and slightly slower for matrix input ([#166](https://github.com/ModelOriented/kernelshap/pull/166)).
+- Additionally, `permshap(, exact = TRUE)` is faster by pre-calculating more 
   elements used across rows [#165](https://github.com/ModelOriented/kernelshap/pull/165)
 
 ### Documentation

--- a/R/kernelshap.R
+++ b/R/kernelshap.R
@@ -82,8 +82,7 @@
 #'   Additional (named) arguments are passed via `...`.
 #'   The default, [stats::predict()], will work in most cases.
 #' @param feature_names Optional vector of column names in `X` used to calculate
-#'   SHAP values. By default, this equals `colnames(X)`. Not supported if `X`
-#'   is a matrix.
+#'   SHAP values. By default, this equals `colnames(X)`.
 #' @param bg_w Optional vector of case weights for each row of `bg_X`.
 #'   If `bg_X = NULL`, must be of same length as `X`. Set to `NULL` for no weights.
 #' @param bg_n If `bg_X = NULL`: Size of background data to be sampled from `X`.
@@ -238,12 +237,6 @@ kernelshap.default <- function(
   txt <- summarize_strategy(p, exact = exact, deg = hybrid_degree)
   if (verbose) {
     message(txt)
-  }
-
-  # Drop unnecessary columns in bg_X. If X is matrix, also column order is relevant
-  # In what follows, predictions will never be applied directly to bg_X anymore
-  if (!identical(colnames(bg_X), feature_names)) {
-    bg_X <- bg_X[, feature_names, drop = FALSE]
   }
 
   # Pre-calculations that are identical for each row to be explained

--- a/R/permshap.R
+++ b/R/permshap.R
@@ -145,7 +145,7 @@ permshap.default <- function(
 
   # Pre-calculations that are identical for each row to be explained
   if (exact) {
-    Z <- exact_Z(p, feature_names = feature_names, keep_extremes = TRUE)
+    Z <- exact_Z(p, feature_names = feature_names)
     m_exact <- nrow(Z) - 2L # We won't evaluate vz for first and last row
     m_eval <- 0L # for consistency with sampling case
     precalc <- list(

--- a/R/permshap.R
+++ b/R/permshap.R
@@ -137,12 +137,6 @@ permshap.default <- function(
   v0 <- wcolMeans(bg_preds, w = bg_w) # Average pred of bg data: 1 x K
   v1 <- align_pred(pred_fun(object, X, ...)) # Predictions on X:        n x K
 
-  # Drop unnecessary columns in bg_X. If X is matrix, also column order is relevant
-  # Predictions will never be applied directly to bg_X anymore
-  if (!identical(colnames(bg_X), feature_names)) {
-    bg_X <- bg_X[, feature_names, drop = FALSE]
-  }
-
   # Pre-calculations that are identical for each row to be explained
   if (exact) {
     Z <- exact_Z(p, feature_names = feature_names)

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,19 +49,13 @@ wcolMeans <- function(x, w = NULL, ...) {
 #'
 #' @param p Number of features.
 #' @param feature_names Feature names.
-#' @param keep_extremes Should extremes be kept? Defaults to `FALSE` (for kernelshap).
 #' @returns An integer matrix of all on-off vectors of length `p`.
-exact_Z <- function(p, feature_names, keep_extremes = FALSE) {
+exact_Z <- function(p, feature_names) {
   if (p < 2L) {
     stop("p must be at least 2 if exact = TRUE.")
   }
   m <- 2^p
-  if (keep_extremes) {
-    M <- seq_len(m) - 1L
-  } else {
-    M <- seq_len(m - 2L)
-    m <- m - 2L
-  }
+  M <- seq_len(m) - 1L
   encoded <- as.integer(intToBits(M))
   dim(encoded) <- c(32L, m)
   Z <- t(encoded[p:1L, , drop = FALSE])

--- a/R/utils_kernelshap.R
+++ b/R/utils_kernelshap.R
@@ -1,8 +1,21 @@
 # Kernel SHAP algorithm for a single row x
 # If exact, a single call to predict() is necessary.
 # If sampling is involved, we need at least two additional calls to predict().
-kernelshap_one <- function(x, v1, object, pred_fun, feature_names, bg_w, exact, deg,
-                           m, tol, max_iter, v0, precalc, ...) {
+kernelshap_one <- function(
+    x,
+    v1,
+    object,
+    pred_fun,
+    feature_names,
+    bg_w,
+    exact,
+    deg,
+    m,
+    tol,
+    max_iter,
+    v0,
+    precalc,
+    ...) {
   p <- length(feature_names)
   K <- ncol(v1)
   K_names <- colnames(v1)
@@ -16,14 +29,8 @@ kernelshap_one <- function(x, v1, object, pred_fun, feature_names, bg_w, exact, 
     v0_m_exact <- v0[rep.int(1L, m_exact), , drop = FALSE] #  (m_ex x K)
 
     # Most expensive part
-    vz <- get_vz( #  (m_ex x K)
-      X = rep_rows(x, rep.int(1L, nrow(bg_X_exact))), #  (m_ex*n_bg x p)
-      bg = bg_X_exact, #  (m_ex*n_bg x p)
-      Z = Z, #  (m_ex x p)
-      object = object,
-      pred_fun = pred_fun,
-      w = bg_w,
-      ...
+    vz <- get_vz(
+      x = x, bg = bg_X_exact, Z = Z, object = object, pred_fun = pred_fun, w = bg_w, ...
     )
     # Note: w is correctly replicated along columns of (vz - v0_m_exact)
     b_exact <- crossprod(Z, precalc[["w"]] * (vz - v0_m_exact)) #  (p x K)
@@ -37,7 +44,6 @@ kernelshap_one <- function(x, v1, object, pred_fun, feature_names, bg_w, exact, 
 
   # Iterative sampling part, always using A_exact and b_exact to fill up the weights
   bg_X_m <- precalc[["bg_X_m"]] #  (m*n_bg x p)
-  X <- rep_rows(x, rep.int(1L, nrow(bg_X_m))) #  (m*n_bg x p)
   v0_m <- v0[rep.int(1L, m), , drop = FALSE] #  (m x K)
   est_m <- array(
     data = 0, dim = c(max_iter, p, K), dimnames = list(NULL, feature_names, K_names)
@@ -60,7 +66,7 @@ kernelshap_one <- function(x, v1, object, pred_fun, feature_names, bg_w, exact, 
 
     # Expensive                                                              #  (m x K)
     vz <- get_vz(
-      X = X, bg = bg_X_m, Z = Z, object = object, pred_fun = pred_fun, w = bg_w, ...
+      x = x, bg = bg_X_m, Z = Z, object = object, pred_fun = pred_fun, w = bg_w, ...
     )
 
     # The sum of weights of A_exact and input[["A"]] is 1, same for b
@@ -152,7 +158,7 @@ input_sampling <- function(p, m, deg, feature_names) {
 # - A: Exact matrix A = Z'wZ
 input_exact <- function(p, feature_names) {
   Z <- exact_Z(p, feature_names = feature_names)
-  Z <- Z[2L:nrow(Z) - 1L, , drop = FALSE]
+  Z <- Z[2L:(nrow(Z) - 1L), , drop = FALSE]
   # Each Kernel weight(j) is divided by the number of vectors z having sum(z) = j
   w <- kernel_weights(p) / choose(p, 1:(p - 1L))
   list(Z = Z, w = w[rowSums(Z)], A = exact_A(p, feature_names = feature_names))

--- a/R/utils_kernelshap.R
+++ b/R/utils_kernelshap.R
@@ -151,7 +151,8 @@ input_sampling <- function(p, m, deg, feature_names) {
 #      the SHAP kernel distribution
 # - A: Exact matrix A = Z'wZ
 input_exact <- function(p, feature_names) {
-  Z <- exact_Z(p, feature_names = feature_names, keep_extremes = FALSE)
+  Z <- exact_Z(p, feature_names = feature_names)
+  Z <- Z[2L:nrow(Z) - 1L, , drop = FALSE]
   # Each Kernel weight(j) is divided by the number of vectors z having sum(z) = j
   w <- kernel_weights(p) / choose(p, 1:(p - 1L))
   list(Z = Z, w = w[rowSums(Z)], A = exact_A(p, feature_names = feature_names))

--- a/R/utils_permshap.R
+++ b/R/utils_permshap.R
@@ -28,7 +28,6 @@ permshap_one <- function(
     max_iter,
     ...) {
   bg <- precalc$bg_X_rep
-  X <- rep_rows(x, rep.int(1L, times = nrow(bg)))
 
   p <- length(feature_names)
   K <- ncol(v1)
@@ -38,7 +37,7 @@ permshap_one <- function(
   if (exact) {
     Z <- precalc$Z # ((m_ex+2) x K)
     vz <- get_vz( # (m_ex x K)
-      X = X,
+      x = x,
       bg = bg,
       Z = Z[2L:(nrow(Z) - 1L), , drop = FALSE], # (m_ex x p)
       object = object,
@@ -52,7 +51,7 @@ permshap_one <- function(
       pos <- precalc$positions[[j]]
       beta_n[j, ] <- wcolMeans(
         vz[pos$on, , drop = FALSE] - vz[pos$off, , drop = FALSE],
-        weights = precalc["shapley_w"][pos$on]
+        w = precalc$shapley_w[pos$on]
       )
     }
     return(list(beta = beta_n))
@@ -68,7 +67,7 @@ permshap_one <- function(
 
   # Pre-calculate part of Z with rowsum 1 or p - 1
   vz_balanced <- get_vz( # (2p x K)
-    X = rep_rows(x, rep.int(1L, times = nrow(precalc$bg_X_balanced))),
+    x = x,
     bg = precalc$bg_X_balanced,
     Z = precalc$Z_balanced,
     object = object,
@@ -90,13 +89,19 @@ permshap_one <- function(
     if (!low_memory) { # predictions for all chains at once
       Z <- do.call(rbind, Z)
       vz <- get_vz(
-        X = X, bg = bg, Z = Z, object = object, pred_fun = pred_fun, w = bg_w, ...
+        x = x, bg = bg, Z = Z, object = object, pred_fun = pred_fun, w = bg_w, ...
       )
     } else { # predictions for each chain separately
       vz <- vector("list", length = p)
       for (j in seq_len(p)) {
         vz[[j]] <- get_vz(
-          X = X, bg = bg, Z = Z[[j]], object = object, pred_fun = pred_fun, w = bg_w, ...
+          x = x,
+          bg = bg,
+          Z = Z[[j]],
+          object = object,
+          pred_fun = pred_fun,
+          w = bg_w,
+          ...
         )
       }
       vz <- do.call(rbind, vz)

--- a/R/utils_permshap.R
+++ b/R/utils_permshap.R
@@ -142,20 +142,6 @@ shapley_weights <- function(p, ell) {
   1 / choose(p, ell) / (p - ell)
 }
 
-#' Rowwise Paste
-#'
-#' Fast version of `apply(Z, 1L, FUN = paste0, collapse = "")`.
-#' Required for exact permutation SHAP only.
-#'
-#' @noRd
-#' @keywords internal
-#'
-#' @param Z A (n x p) matrix.
-#' @returns A length n vector.
-rowpaste <- function(Z) {
-  do.call(paste0, asplit(Z, 2L))
-}
-
 #' Balanced Chains
 #'
 #' Creates `p` permutations of the numbers `1:p` such that each number appears once
@@ -249,7 +235,7 @@ init_vzj <- function(p, v0, v1) {
 #' @noRd
 #' @keywords internal
 #'
-#' @param mask The output of `exact_Z(p, feature_names, keep_extremes = TRUE)`.
+#' @param mask The output of `exact_Z(p, feature_names)`.
 #' @returns List with p elements, each containing an `on` and `off` vector.
 positions_for_exact <- function(mask) {
   p <- ncol(mask)

--- a/backlog/compare_with_python.R
+++ b/backlog/compare_with_python.R
@@ -31,6 +31,18 @@ system.time(
 )
 ks2
 
+bench::mark(kernelshap(fit, X_small, bg_X = bg_X, verbose=F))
+# 2.17s 1.64GB -> 1.72s 1.44GB
+
+bench::mark(kernelshap(fit, X_small, bg_X = bg_X, verbose=F, exact=F, hybrid_degree = 1))
+# 4.88s  2.79GB ->  4.38s 2.48GB
+
+bench::mark(permshap(fit, X_small, bg_X = bg_X, verbose=F))
+# 1.97s 1.64GB -> 1.8s 1.43GB
+
+bench::mark(permshap(fit, X_small, bg_X = bg_X, verbose=F, exact=F))
+# 3.04s  1.88GB ->  2.9s 1.64GB
+
 # SHAP values of first 2 observations:
 #          carat     clarity     color        cut
 # [1,] -2.050074 -0.28048747 0.1281222 0.01587382
@@ -54,7 +66,7 @@ fit <- lm(
 X_small <- diamonds[seq(1, nrow(diamonds), 53), setdiff(names(diamonds), "price")]
 
 # Exact KernelSHAP on X_small, using X_small as background data
-# (39s for exact, 15s for hybrid deg 2, 8s for hybrid deg 1, 16s for sampling)
+# (38s for exact, 11s for hybrid deg 2, 7s for hybrid deg 1, 11s for sampling)
 system.time(
   ks <- kernelshap(fit, X_small, bg_X = bg_X)
 )

--- a/man/kernelshap.Rd
+++ b/man/kernelshap.Rd
@@ -70,8 +70,7 @@ Additional (named) arguments are passed via \code{...}.
 The default, \code{\link[stats:predict]{stats::predict()}}, will work in most cases.}
 
 \item{feature_names}{Optional vector of column names in \code{X} used to calculate
-SHAP values. By default, this equals \code{colnames(X)}. Not supported if \code{X}
-is a matrix.}
+SHAP values. By default, this equals \code{colnames(X)}.}
 
 \item{bg_w}{Optional vector of case weights for each row of \code{bg_X}.
 If \code{bg_X = NULL}, must be of same length as \code{X}. Set to \code{NULL} for no weights.}

--- a/man/permshap.Rd
+++ b/man/permshap.Rd
@@ -68,8 +68,7 @@ Additional (named) arguments are passed via \code{...}.
 The default, \code{\link[stats:predict]{stats::predict()}}, will work in most cases.}
 
 \item{feature_names}{Optional vector of column names in \code{X} used to calculate
-SHAP values. By default, this equals \code{colnames(X)}. Not supported if \code{X}
-is a matrix.}
+SHAP values. By default, this equals \code{colnames(X)}.}
 
 \item{bg_w}{Optional vector of case weights for each row of \code{bg_X}.
 If \code{bg_X = NULL}, must be of same length as \code{X}. Set to \code{NULL} for no weights.}

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -175,12 +175,6 @@ test_that("Matrix input is fine", {
     expect_no_error( # additional cols in bg are ok
       algo(fit, X[J, x], pred_fun = pred_fun, bg_X = cbind(d = 1, X), verbose = FALSE)
     )
-    expect_error( # feature_names are less flexible
-      algo(fit, X[J, ],
-        pred_fun = pred_fun, bg_X = X,
-        verbose = FALSE, feature_names = "Sepal.Width"
-      )
-    )
   }
 })
 

--- a/tests/testthat/test-permshap-utils.R
+++ b/tests/testthat/test-permshap-utils.R
@@ -1,8 +1,3 @@
-test_that("rowpaste() does what it should", {
-  M <- cbind(c(0, 0), c(1, 0), c(1, 1))
-  expect_equal(rowpaste(M), c("011", "001"))
-})
-
 test_that("shapley_weights() does what it should", {
   expect_equal(shapley_weights(5, 2), factorial(2) * factorial(5 - 2 - 1) / factorial(5))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -43,14 +43,19 @@ test_that("wcolMeans() gives the same as colMeans() in unweighted case", {
   expect_equal(c(wcolMeans(X, w = c(2, 2, 2))), colMeans(X))
 })
 
-test_that("exact_Z() works for both kernel- and permshap", {
-  p <- 5
-  nm <- LETTERS[1:p]
-  r1 <- exact_Z(p, feature_names = nm, keep_extremes = TRUE)
-  r2 <- exact_Z(p, feature_names = nm, keep_extremes = FALSE)
-  expect_equal(r1[2:(nrow(r1) - 1L), ], r2)
-  expect_equal(colnames(r1), nm)
-  expect_equal(dim(r1), c(2^p, p))
+test_that("exact_Z() works", {
+  for (p in 2:8) {
+    nm <- LETTERS[1:p]
+    r <- exact_Z(p, feature_names = nm)
+    row_sum <- 0
+    for (j in p:1) {
+      row_sum <- row_sum + r[, j] * 2^(p - j)
+    }
+    expect_equal(colnames(r), nm)
+    expect_equal(dim(r), c(2^p, p))
+    expect_equal(row_sum, 0:(2^p - 1))
+  }
+  expect_error(exact_Z(1, "1"))
 })
 
 test_that("rep_rows() gives the same as usual subsetting (except rownames)", {


### PR DESCRIPTION
This PR brings some code changes:

- The masker now does not require replicated x anymore, requiring significantly less memory and bringing some speed-up for data.frames.
- Matrix input can now also be modified by `feature_names`.