### PR TITLE
FIX-bug-in-weighting-logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: kernelshap
 Title: Kernel SHAP
-Version: 0.8.1
+Version: 0.9.0
 Authors@R: c(
     person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0007-2540-9629")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,9 @@
 `kernelshap()` used a wrong weighting logic, leading to values slightly off. This has
   been fixed with the help of Prof Mario Wuethrich of ETHZ and 
   [Ian Covert's wonderful Github repo](https://github.com/iancovert/shapley-regression).
-  Now, exact Kernel SHAP returns identical values than exact permutation SHAP.
+  Now, exact Kernel SHAP returns identical values as exact permutation SHAP.
 
-Fixed in [#167](https://github.com/ModelOriented/kernelshap/pull/167).
+Fixed in [#168](https://github.com/ModelOriented/kernelshap/pull/168).
 
 ### API
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,13 @@
-# kernelshap 0.8.1
+# kernelshap 0.9.0
+
+### Major bug fix
+
+`kernelshap()` used a wrong weighting logic, leading to values slightly off. This has
+  been fixed with the help of Prof Mario Wuethrich of ETHZ and 
+  [Ian Covert's wonderful Github repo](https://github.com/iancovert/shapley-regression).
+  Now, exact Kernel SHAP returns identical values than exact permutation SHAP.
+
+Fixed in [#167](https://github.com/ModelOriented/kernelshap/pull/167).
 
 ### API
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,12 @@
 ### Major bug fix
 
 `kernelshap()` used a wrong weighting logic, leading to values slightly off. This has
-  been fixed with the help of Prof Mario Wuethrich of ETHZ and 
-  [Ian Covert's wonderful Github repo](https://github.com/iancovert/shapley-regression).
-  Now, exact Kernel SHAP returns identical values as exact permutation SHAP.
+been fixed with the help of Prof Mario Wuethrich of ETHZ and Ian Covert and his
+[wonderful Github repo](https://github.com/iancovert/shapley-regression).
+Now, exact Kernel SHAP returns identical values as exact permutation SHAP.
+All variants of `kernelshap()` had been affected by this (exact, sampling, hybrid).
+For models with interactions up to two, the bug had no consequences - which is why
+it went unnoticed.
 
 Fixed in [#168](https://github.com/ModelOriented/kernelshap/pull/168).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,16 @@
 # kernelshap 0.9.0
 
-### Major bug fix
+### Bug fix
 
-`kernelshap()` used a wrong weighting logic, leading to values slightly off. This has
-been fixed with the help of Prof Mario Wuethrich of ETHZ and Ian Covert and his
-[wonderful Github repo](https://github.com/iancovert/shapley-regression).
-Now, exact Kernel SHAP returns identical values as exact permutation SHAP.
-All variants of `kernelshap()` had been affected by this (exact, sampling, hybrid).
-For models with interactions up to two, the bug had no consequences - which is why
-it went unnoticed.
+With input from Mario Wuethrich and Ian Covert and his [repo](https://github.com/iancovert/shapley-regression), 
+we have fixed a bug in how `kernelshap()` calculates Kernel weights. 
 
-Fixed in [#168](https://github.com/ModelOriented/kernelshap/pull/168).
+- The differences caused by this are typically very small.
+- Models with interactions of order up to two have been unaffected.
+- Exact Kernel SHAP now provides identical results to exact permutation SHAP.
+
+Fixed in [#168](https://github.com/ModelOriented/kernelshap/pull/168), which also has received
+unit tests against Python's "shap".
 
 ### API
 

--- a/R/kernelshap.R
+++ b/R/kernelshap.R
@@ -8,17 +8,11 @@
 #' Otherwise, an almost exact hybrid algorithm combining exact calculations and
 #' iterative paired sampling is used, see Details.
 #'
-#' Note that (exact) Kernel SHAP is only an approximation of (exact) permutation SHAP.
-#' Thus, for up to eight features, we recommend [permshap()]. For more features,
-#' [permshap()] tends to be inefficient compared the optimized hybrid strategy
-#' of Kernel SHAP.
-#'
 #' @details
 #' The pure iterative Kernel SHAP sampling as in Covert and Lee (2021) works like this:
 #'
-#' 1. A binary "on-off" vector \eqn{z} is drawn from \eqn{\{0, 1\}^p}
-#'   such that its sum follows the SHAP Kernel weight distribution
-#'   (normalized to the range \eqn{\{1, \dots, p-1\}}).
+#' 1. A binary "on-off" vector \eqn{z} is drawn from \eqn{\{0, 1\}^p} according to
+#'   a special weighting logic.
 #' 2. For each \eqn{j} with \eqn{z_j = 1}, the \eqn{j}-th column of the
 #'   original background data is replaced by the corresponding feature value \eqn{x_j}
 #'   of the observation to be explained.
@@ -33,17 +27,14 @@
 #'
 #' This is repeated multiple times until convergence, see CL21 for details.
 #'
-#' A drawback of this strategy is that many (at least 75%) of the \eqn{z} vectors will
-#' have \eqn{\sum z \in \{1, p-1\}}, producing many duplicates. Similarly, at least 92%
-#' of the mass will be used for the \eqn{p(p+1)} possible vectors with
-#' \eqn{\sum z \in \{1, 2, p-2, p-1\}}.
+#' To avoid the evaluation of
 #' This inefficiency can be fixed by a hybrid strategy, combining exact calculations
 #' with sampling.
 #'
 #' The hybrid algorithm has two steps:
 #' 1. Step 1 (exact part): There are \eqn{2p} different on-off vectors \eqn{z} with
-#'   \eqn{\sum z \in \{1, p-1\}}, covering a large proportion of the Kernel SHAP
-#'   distribution. The degree 1 hybrid will list those vectors and use them according
+#'   \eqn{\sum z \in \{1, p-1\}}.
+#'   The degree 1 hybrid will list those vectors and use them according
 #'   to their weights in the upcoming calculations. Depending on \eqn{p}, we can also go
 #'   a step further to a degree 2 hybrid by adding all \eqn{p(p-1)} vectors with
 #'   \eqn{\sum z \in \{2, p-2\}} to the process etc. The necessary predictions are
@@ -96,12 +87,10 @@
 #'     worse than the hybrid strategy and should therefore only be used for
 #'     studying properties of the Kernel SHAP algorithm.
 #'   - `1`: Uses all \eqn{2p} on-off vectors \eqn{z} with \eqn{\sum z \in \{1, p-1\}}
-#'     for the exact part, which covers at least 75% of the mass of the Kernel weight
-#'     distribution. The remaining mass is covered by random sampling.
+#'     for the exact part. The remaining mass is covered by random sampling.
 #'   - `2`: Uses all \eqn{p(p+1)} on-off vectors \eqn{z} with
-#'     \eqn{\sum z \in \{1, 2, p-2, p-1\}}. This covers at least 92% of the mass of the
-#'     Kernel weight distribution. The remaining mass is covered by sampling.
-#'     Convergence usually happens in the minimal possible number of iterations of two.
+#'     \eqn{\sum z \in \{1, 2, p-2, p-1\}}. The remaining mass is covered by sampling.
+#'     Convergence usually happens very fast.
 #'   - `k>2`: Uses all on-off vectors with
 #'     \eqn{\sum z \in \{1, \dots, k, p-k, \dots, p-1\}}.
 #' @param m Even number of on-off vectors sampled during one iteration.

--- a/R/kernelshap.R
+++ b/R/kernelshap.R
@@ -27,9 +27,8 @@
 #'
 #' This is repeated multiple times until convergence, see CL21 for details.
 #'
-#' To avoid the evaluation of
-#' This inefficiency can be fixed by a hybrid strategy, combining exact calculations
-#' with sampling.
+#' To avoid the re-evaluation of identical coalition vectors, we have implemented
+#' a hybrid strategy, combining exact calculations with sampling.
 #'
 #' The hybrid algorithm has two steps:
 #' 1. Step 1 (exact part): There are \eqn{2p} different on-off vectors \eqn{z} with

--- a/R/permshap.R
+++ b/R/permshap.R
@@ -32,7 +32,7 @@
 #' Furthermore, the 2p on-off vectors with sum <=1 or >=p-1 are evaluated only once,
 #' similar to the degree 1 hybrid in [kernelshap()] (but covering less weight).
 #'
-#' @param exact If `TRUE`, the algorithm will produce exact SHAP values
+#' @param exact If `TRUE`, the algorithm produces exact SHAP values
 #'   with respect to the background data.
 #'   The default is `TRUE` for up to eight features, and `FALSE` otherwise.
 #' @param low_memory If `FALSE` (default up to p = 15), the algorithm evaluates p

--- a/R/utils_kernelshap.R
+++ b/R/utils_kernelshap.R
@@ -107,8 +107,7 @@ solver <- function(A, b, constraint) {
 # to Kernel SHAP weights -> (m x p) matrix.
 # The argument S can be used to restrict the range of sum(z).
 sample_Z <- function(p, m, feature_names, S = 1:(p - 1L)) {
-  # First draw s = sum(z) according to Kernel weights (renormalized to sum 1)
-  probs <- kernel_weights(p, S = S)
+  probs <- kernel_weights_per_coalition_size(p, S = S)
   N <- S[sample.int(length(S), m, replace = TRUE, prob = probs)]
 
   # Then, conditional on that number, set random positions of z to 1
@@ -144,8 +143,8 @@ input_sampling <- function(p, m, deg, feature_names) {
   S <- (deg + 1L):(p - deg - 1L)
   Z <- sample_Z(p = p, m = m / 2, feature_names = feature_names, S = S)
   Z <- rbind(Z, !Z)
-  w_total <- if (deg == 0L) 1 else 1 - 2 * sum(kernel_weights(p)[seq_len(deg)])
-  w <- w_total / m
+  w <- if (deg == 0L) 1 else 1 - prop_exact(p, deg = deg)
+  w <- w / m
   list(Z = Z, w = rep.int(w, m), A = crossprod(Z) * w)
 }
 
@@ -159,33 +158,10 @@ input_sampling <- function(p, m, deg, feature_names) {
 input_exact <- function(p, feature_names) {
   Z <- exact_Z(p, feature_names = feature_names)
   Z <- Z[2L:(nrow(Z) - 1L), , drop = FALSE]
-  # Each Kernel weight(j) is divided by the number of vectors z having sum(z) = j
-  w <- kernel_weights(p) / choose(p, 1:(p - 1L))
-  list(Z = Z, w = w[rowSums(Z)], A = exact_A(p, feature_names = feature_names))
-}
-
-#' Exact Matrix A
-#'
-#' Internal function that calculates exact A.
-#' Notice the difference to the off-diagnonals in the Supplement of
-#' Covert and Lee (2021). Credits to David Watson for figuring out the correct formula,
-#' see our discussions in https://github.com/ModelOriented/kernelshap/issues/22
-#'
-#' @noRd
-#' @keywords internal
-#'
-#' @param p Number of features.
-#' @param feature_names Feature names.
-#' @returns A (p x p) matrix.
-exact_A <- function(p, feature_names) {
-  S <- 1:(p - 1L)
-  c_pr <- S * (S - 1) / p / (p - 1)
-  off_diag <- sum(kernel_weights(p) * c_pr)
-  A <- matrix(
-    data = off_diag, nrow = p, ncol = p, dimnames = list(feature_names, feature_names)
-  )
-  diag(A) <- 0.5
-  A
+  kw <- kernel_weights(p) # Kernel weights for all subsets
+  w <- kw[rowSums(Z)] # Corresponding weight for each row in Z
+  w <- w / sum(w)
+  list(Z = Z, w = w, A = crossprod(Z, w * Z))
 }
 
 # List all length p vectors z with sum(z) in {k, p - k}
@@ -228,22 +204,37 @@ input_partly_exact <- function(p, deg, feature_names) {
   }
 
   kw <- kernel_weights(p)
-  Z <- w <- vector("list", deg)
 
+  Z <- vector("list", deg)
   for (k in seq_len(deg)) {
     Z[[k]] <- partly_exact_Z(p, k = k, feature_names = feature_names)
-    n <- nrow(Z[[k]])
-    w_tot <- kw[k] * (2 - (p == 2L * k))
-    w[[k]] <- rep.int(w_tot / n, n)
   }
-  w <- unlist(w, recursive = FALSE, use.names = FALSE)
   Z <- do.call(rbind, Z)
-
+  w <- kw[rowSums(Z)]
+  w_target <- prop_exact(p, deg = deg) # How much of total weight to spend here
+  w <- w / sum(w) * w_target
   list(Z = Z, w = w, A = crossprod(Z, w * Z))
 }
 
-# Kernel weights normalized to a non-empty subset S of {1, ..., p-1}
+# Kernel weights
 kernel_weights <- function(p, S = seq_len(p - 1L)) {
   probs <- (p - 1L) / (choose(p, S) * S * (p - S))
-  probs / sum(probs)
+  return(probs / sum(probs))
+}
+
+# Kernel weights per coalition size
+kernel_weights_per_coalition_size <- function(p, S = seq_len(p - 1L)) {
+  probs <- 1 / (S * (p - S))
+  return(probs / sum(probs))
+}
+
+# How much Kernel SHAP weights do coalitions of size
+# {1, ..., deg, ..., p-deg-1 ..., p-1} have?
+prop_exact <- function(p, deg) {
+  if (deg == 0) {
+    return(0)
+  }
+  w <- kernel_weights_per_coalition_size(p)
+  w_total <- 2 * sum(w[seq_len(deg)]) - w[deg] * (p == 2 * deg)
+  return(w_total)
 }

--- a/R/utils_kernelshap.R
+++ b/R/utils_kernelshap.R
@@ -107,7 +107,7 @@ solver <- function(A, b, constraint) {
 # to Kernel SHAP weights -> (m x p) matrix.
 # The argument S can be used to restrict the range of sum(z).
 sample_Z <- function(p, m, feature_names, S = 1:(p - 1L)) {
-  probs <- kernel_weights_per_coalition_size(p, S = S)
+  probs <- kernel_weights(p, per_coalition_size = TRUE, S = S)
   N <- S[sample.int(length(S), m, replace = TRUE, prob = probs)]
 
   # Then, conditional on that number, set random positions of z to 1
@@ -158,7 +158,7 @@ input_sampling <- function(p, m, deg, feature_names) {
 input_exact <- function(p, feature_names) {
   Z <- exact_Z(p, feature_names = feature_names)
   Z <- Z[2L:(nrow(Z) - 1L), , drop = FALSE]
-  kw <- kernel_weights(p) # Kernel weights for all subsets
+  kw <- kernel_weights(p, per_coalition_size = FALSE) # Kernel weights for all subsets
   w <- kw[rowSums(Z)] # Corresponding weight for each row in Z
   w <- w / sum(w)
   list(Z = Z, w = w, A = crossprod(Z, w * Z))
@@ -203,7 +203,7 @@ input_partly_exact <- function(p, deg, feature_names) {
     stop("p must be >=2*deg")
   }
 
-  kw <- kernel_weights(p)
+  kw <- kernel_weights(p, per_coalition_size = FALSE)
 
   Z <- vector("list", deg)
   for (k in seq_len(deg)) {
@@ -216,15 +216,16 @@ input_partly_exact <- function(p, deg, feature_names) {
   list(Z = Z, w = w, A = crossprod(Z, w * Z))
 }
 
-# Kernel weights
-kernel_weights <- function(p, S = seq_len(p - 1L)) {
-  probs <- (p - 1L) / (choose(p, S) * S * (p - S))
-  return(probs / sum(probs))
-}
-
-# Kernel weights per coalition size
-kernel_weights_per_coalition_size <- function(p, S = seq_len(p - 1L)) {
-  probs <- 1 / (S * (p - S))
+# Kernel weight distribution
+#
+# `per_coalition_size = TRUE` is required, e.g., when one wants to sample random masks
+# according to the Kernel SHAP distribution: Pick a coalition size as per
+# these weights, then randomly place "on" positions. `FALSE` refer to weights
+# if all masks has been calculated and one wants to calculate their weights based
+# on the number of "on" positions.
+kernel_weights <- function(p, per_coalition_size, S = seq_len(p - 1L)) {
+  const <- if (per_coalition_size) 1 else choose(p, S)
+  probs <- (p - 1) / (const * S * (p - S)) # could drop the numerator
   return(probs / sum(probs))
 }
 
@@ -234,7 +235,7 @@ prop_exact <- function(p, deg) {
   if (deg == 0) {
     return(0)
   }
-  w <- kernel_weights_per_coalition_size(p)
+  w <- kernel_weights(p, per_coalition_size = TRUE)
   w_total <- 2 * sum(w[seq_len(deg)]) - w[deg] * (p == 2 * deg)
   return(w_total)
 }

--- a/README.md
+++ b/README.md
@@ -15,20 +15,18 @@
 
 The package contains three functions to crunch SHAP values:
 
-- **`permshap()`**: Permutation SHAP algorithm of [1]. Recommended for models with up to 8 features, or if you don't trust Kernel SHAP. Both exact and sampling versions are available.
-- **`kernelshap()`**: Kernel SHAP algorithm of [2] and [3]. Recommended for models with more than 8 features. Both exact and (pseudo-exact) sampling versions are available.
+- **`permshap()`**: Permutation SHAP algorithm of [1]. Both exact and sampling versions are available.
+- **`kernelshap()`**: Kernel SHAP algorithm of [2] and [3]. Both exact and (pseudo-exact) sampling versions are available.
 - **`additive_shap()`**: For *additive models* fitted via `lm()`, `glm()`, `mgcv::gam()`, `mgcv::bam()`, `gam::gam()`, `survival::coxph()`, or `survival::survreg()`. Exponentially faster than the model-agnostic options above, and recommended if possible.
 
-To explain your model, select an explanation dataset `X` (up to 1000 rows from the training data, feature columns only) and apply the recommended function. Use {shapviz} to visualize the resulting SHAP values. 
+To explain your model, select an explanation dataset `X` (up to 1000 rows from the training data, feature columns only). Use {shapviz} to visualize the resulting SHAP values. 
 
 **Remarks to `permshap()` and `kernelshap()`**
 
 - Both algorithms need a representative background data `bg_X` to calculate marginal means (up to 500 rows from the training data). In cases with a natural "off" value (like MNIST digits), this can also be a single row with all values set to the off value. If unspecified, 200 rows are randomly sampled from `X`.
-- Exact Kernel SHAP is an approximation to exact permutation SHAP. Since exact calculations are usually sufficiently fast for up to eight features, we recommend `permshap()` in this case. With more features, `kernelshap()` switches to a comparably fast, almost exact algorithm with faster convergence than the sampling version of permutation SHAP.
-  That is why we recommend `kernelshap()` in this case.
-- For models with interactions of order up to two, SHAP values of permutation SHAP and Kernel SHAP agree, 
-and the implemented sampling versions provide the same results as the exact versions.
-In the presence of interactions of order three or higher, this is no longer the case.
+- Exact Kernel SHAP gives identical results as exact permutation SHAP. Both algorithms are fast up to 8 features.
+  With more features, `kernelshap()` switches to an almost exact algorithm with faster convergence than the sampling version of permutation SHAP.
+- For models with interactions of order up to two, the sampling versions provide the same results as the exact versions.
 - For additive models, `permshap()` and `kernelshap()` give the same results as `additive_shap` 
 as long as the full training data would be used as background data.
 
@@ -89,13 +87,12 @@ ps
 [1,]  1.1913247  0.09005467 -0.13430720 0.000682593
 [2,] -0.4931989 -0.11724773  0.09868921 0.028563613
 
-# Kernel SHAP gives very slightly different values because the model contains
-# interations of order > 2:
+# Indeed, Kernel SHAP gives the same:
 ks <- kernelshap(fit, X, bg_X = bg_X)
 ks
-#       log_carat     clarity       color        cut
-# [1,]  1.1911791  0.0900462 -0.13531648 0.001845958
-# [2,] -0.4927482 -0.1168517  0.09815062 0.028255442
+      log_carat     clarity       color         cut
+[1,]  1.1913247  0.09005467 -0.13430720 0.000682593
+[2,] -0.4931989 -0.11724773  0.09868921 0.028563613
 
 # 4) Analyze with {shapviz}
 ps <- shapviz(ps)

--- a/backlog/compare_with_python2.R
+++ b/backlog/compare_with_python2.R
@@ -1,0 +1,63 @@
+library(kernelshap)
+
+n <- 100
+
+X <- data.frame(
+  x1 = seq(1:n) / 100,
+  x2 = log(1:n),
+  x3 = sqrt(1:n),
+  x4 = sin(1:n),
+  x5 = (seq(1:n) / 100)^2,
+  x6 = cos(1:n)
+)
+head(X)
+
+pf <- function(model, newdata) {
+  x <- newdata
+  x[, 1] * x[, 2] * x[, 3] * x[, 4] + x[, 5] + x[, 6]
+}
+ks <- kernelshap(pf, head(X), bg_X = X, pred_fun = pf)
+ks # -1.196216 -1.241848 -0.9567848 3.879420 -0.33825  0.5456252
+es <- permshap(pf, head(X), bg_X = X, pred_fun = pf)
+es # -1.196216 -1.241848 -0.9567848 3.879420 -0.33825  0.5456252
+
+set.seed(10)
+kss <- kernelshap(
+  pf,
+  head(X, 1),
+  bg_X = X,
+  pred_fun = pf,
+  hybrid_degree = 0,
+  exact = F,
+  m = 9000,
+  max_iter = 100,
+  tol = 0.0005
+)
+kss # -1.198078 -1.246508 -0.9580638 3.877532 -0.3241824 0.541247
+
+set.seed(2)
+ksh <- kernelshap(
+  pf,
+  head(X, 1),
+  bg_X = X,
+  pred_fun = pf,
+  hybrid_degree = 1,
+  exact = FALSE,
+  max_iter = 10000,
+  tol = 0.0005
+)
+ksh # -1.191981 -1.240656 -0.9516264 3.86776 -0.3342143 0.5426642
+
+set.seed(1)
+ksh2 <- kernelshap(
+  pf,
+  head(X, 1),
+  bg_X = X,
+  pred_fun = pf,
+  hybrid_degree = 2,
+  exact = FALSE,
+  m = 10000,
+  max_iter = 10000,
+  tol = 0.0001
+)
+ksh2 # 1.195976 -1.241107 -0.9565121 3.878891 -0.3384621 0.5451118

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,14 @@
-# kernelshap 0.8.0
+# kernelshap 0.9.0 (MAJOR BUG FIX)
 
-Dear CRAN team
+We have figured out a major bug in the weighting logic of Kernel SHAP.
 
-The package (finally!) contains a sampling version of permutation SHAP. In contrast 
-to other implementations, it iterates until convergence, and standard errors are provided.
+This update comes with a fix which has been tested also against different
+Python algorithms.
+
+I know that summer holidays are ahead, and the last release is not long ago, 
+but I would love to see this change on CRAN very soon.
+
+Michael
 
 ## Checks
 
@@ -18,9 +23,8 @@ R Under development (unstable) (2025-07-05 r88387 ucrt)
 
 ### Revdep OK
 
-survex 1.2.0                           ── E: 0     | W: 0     | N: 0
-XAItest 1.0.1                          ── E: 1     | W: 0     | N: 0
-SEMdeep 1.0.0                          ── E: 1     | W: 1     | N: 0     
+✔ survex 1.2.0                           ── E: 0     | W: 0     | N: 0        
+✔ XAItest 1.0.1                          ── E: 1     | W: 0     | N: 0        
+✔ SEMdeep 1.0.0                          ── E: 1     | W: 1     | N: 0  
 
-OK: 3
-BROKEN: 0
+OK: 3     

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,13 @@
-# kernelshap 0.9.0 (MAJOR BUG FIX)
+# kernelshap 0.9.0
 
-We have figured out a major bug in the weighting logic of Kernel SHAP.
+We have figured out a bug in the weighting logic of Kernel SHAP.
 
-This update comes with a fix which has been tested also against different
-Python algorithms.
+This update comes with a fix which has been tested against two other implementations.
 
-I know that summer holidays are ahead, and the last release is not long ago, 
-but I would love to see this change on CRAN very soon.
+I am aware that the last release of {kernelshap} is not too long ago, but I still would love to see
+this fixed before the (well-deserved) summer break.
 
-Michael
+Thanks a lot!
 
 ## Checks
 

--- a/man/kernelshap.Rd
+++ b/man/kernelshap.Rd
@@ -89,12 +89,10 @@ Ignored if \code{exact = TRUE}.
 worse than the hybrid strategy and should therefore only be used for
 studying properties of the Kernel SHAP algorithm.
 \item \code{1}: Uses all \eqn{2p} on-off vectors \eqn{z} with \eqn{\sum z \in \{1, p-1\}}
-for the exact part, which covers at least 75\% of the mass of the Kernel weight
-distribution. The remaining mass is covered by random sampling.
+for the exact part. The remaining mass is covered by random sampling.
 \item \code{2}: Uses all \eqn{p(p+1)} on-off vectors \eqn{z} with
-\eqn{\sum z \in \{1, 2, p-2, p-1\}}. This covers at least 92\% of the mass of the
-Kernel weight distribution. The remaining mass is covered by sampling.
-Convergence usually happens in the minimal possible number of iterations of two.
+\eqn{\sum z \in \{1, 2, p-2, p-1\}}. The remaining mass is covered by sampling.
+Convergence usually happens very fast.
 \item \code{k>2}: Uses all on-off vectors with
 \eqn{\sum z \in \{1, \dots, k, p-k, \dots, p-1\}}.
 }}
@@ -163,18 +161,12 @@ By default, for up to p=8 features, exact Kernel SHAP values are returned
 (with respect to the selected background data).
 Otherwise, an almost exact hybrid algorithm combining exact calculations and
 iterative paired sampling is used, see Details.
-
-Note that (exact) Kernel SHAP is only an approximation of (exact) permutation SHAP.
-Thus, for up to eight features, we recommend \code{\link[=permshap]{permshap()}}. For more features,
-\code{\link[=permshap]{permshap()}} tends to be inefficient compared the optimized hybrid strategy
-of Kernel SHAP.
 }
 \details{
 The pure iterative Kernel SHAP sampling as in Covert and Lee (2021) works like this:
 \enumerate{
-\item A binary "on-off" vector \eqn{z} is drawn from \eqn{\{0, 1\}^p}
-such that its sum follows the SHAP Kernel weight distribution
-(normalized to the range \eqn{\{1, \dots, p-1\}}).
+\item A binary "on-off" vector \eqn{z} is drawn from \eqn{\{0, 1\}^p} according to
+a special weighting logic.
 \item For each \eqn{j} with \eqn{z_j = 1}, the \eqn{j}-th column of the
 original background data is replaced by the corresponding feature value \eqn{x_j}
 of the observation to be explained.
@@ -190,18 +182,15 @@ observation to be explained. The resulting coefficients are the Kernel SHAP valu
 
 This is repeated multiple times until convergence, see CL21 for details.
 
-A drawback of this strategy is that many (at least 75\%) of the \eqn{z} vectors will
-have \eqn{\sum z \in \{1, p-1\}}, producing many duplicates. Similarly, at least 92\%
-of the mass will be used for the \eqn{p(p+1)} possible vectors with
-\eqn{\sum z \in \{1, 2, p-2, p-1\}}.
+To avoid the evaluation of
 This inefficiency can be fixed by a hybrid strategy, combining exact calculations
 with sampling.
 
 The hybrid algorithm has two steps:
 \enumerate{
 \item Step 1 (exact part): There are \eqn{2p} different on-off vectors \eqn{z} with
-\eqn{\sum z \in \{1, p-1\}}, covering a large proportion of the Kernel SHAP
-distribution. The degree 1 hybrid will list those vectors and use them according
+\eqn{\sum z \in \{1, p-1\}}.
+The degree 1 hybrid will list those vectors and use them according
 to their weights in the upcoming calculations. Depending on \eqn{p}, we can also go
 a step further to a degree 2 hybrid by adding all \eqn{p(p-1)} vectors with
 \eqn{\sum z \in \{2, p-2\}} to the process etc. The necessary predictions are

--- a/man/kernelshap.Rd
+++ b/man/kernelshap.Rd
@@ -182,9 +182,8 @@ observation to be explained. The resulting coefficients are the Kernel SHAP valu
 
 This is repeated multiple times until convergence, see CL21 for details.
 
-To avoid the evaluation of
-This inefficiency can be fixed by a hybrid strategy, combining exact calculations
-with sampling.
+To avoid the re-evaluation of identical coalition vectors, we have implemented
+a hybrid strategy, combining exact calculations with sampling.
 
 The hybrid algorithm has two steps:
 \enumerate{

--- a/man/permshap.Rd
+++ b/man/permshap.Rd
@@ -75,7 +75,7 @@ If \code{bg_X = NULL}, must be of same length as \code{X}. Set to \code{NULL} fo
 
 \item{bg_n}{If \code{bg_X = NULL}: Size of background data to be sampled from \code{X}.}
 
-\item{exact}{If \code{TRUE}, the algorithm will produce exact SHAP values
+\item{exact}{If \code{TRUE}, the algorithm produces exact SHAP values
 with respect to the background data.
 The default is \code{TRUE} for up to eight features, and \code{FALSE} otherwise.}
 

--- a/packaging.R
+++ b/packaging.R
@@ -15,7 +15,7 @@ library(usethis)
 use_description(
   fields = list(
     Title = "Kernel SHAP",
-    Version = "0.8.1",
+    Version = "0.9.0",
     Description = "Efficient implementation of Kernel SHAP
     (Lundberg and Lee, 2017, <doi:10.48550/arXiv.1705.07874>)
     permutation SHAP, and additive SHAP for model interpretability.

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -10,7 +10,7 @@
 |collate  |English_Switzerland.utf8                |
 |ctype    |English_Switzerland.utf8                |
 |tz       |Europe/Zurich                           |
-|date     |2025-07-07                              |
+|date     |2025-07-19                              |
 |rstudio  |2025.05.0+496 Mariposa Orchid (desktop) |
 |pandoc   |NA                                      |
 
@@ -18,7 +18,7 @@
 
 |package    |old    |new    |Δ  |
 |:----------|:------|:------|:--|
-|kernelshap |0.7.0  |0.8.0  |*  |
+|kernelshap |0.8.0  |0.9.0  |*  |
 |foreach    |1.5.2  |1.5.2  |   |
 |iterators  |1.0.14 |1.0.14 |   |
 

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -284,7 +284,7 @@ test_that("kernelshap and permshap work for models with high-order interactions"
     hybrid_degree = 2,
     exact = FALSE,
     m = 1000,
-    max_iter = 100, ,
+    max_iter = 100,
     tol = 0.001,
     verbose = FALSE
   )

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -213,3 +213,124 @@ test_that("kernelshap works for large p (hybrid case)", {
   expect_equal(s$baseline, mean(y))
   expect_equal(rowSums(s$S) + s$baseline, unname(predict(fit, X[1L, ])))
 })
+
+test_that("kernelshap and permshap work for models with high-order interactions", {
+  # Expected: Python output
+  # import numpy as np
+  # import shap 0.47.2
+  #
+  # X = np.array(
+  #   [
+  #     np.arange(1, 101) / 100,
+  #     np.log(np.arange(1, 101)),
+  #     np.sqrt(np.arange(1, 101)),
+  #     np.sin(np.arange(1, 101)),
+  #     (np.arange(1, 101) / 100) ** 2,
+  #     np.cos(np.arange(1, 101)),
+  #   ]
+  # ).T
+  #
+  #
+  # def predict(X):
+  #   return X[:, 0] * X[:, 1] * X[:, 2] * X[:, 3] + X[:, 4] + X[:, 5]
+  #
+  #
+  # ks = shap.explainers.Kernel(predict, X, nsamples=10000)
+  # es = shap.explainers.Exact(predict, X)
+  #
+  # print("Exact Kernel SHAP:\n", ks(X[0:2]).values)
+  # print("Exact (Permutation) SHAP:\n", es(X[0:2]).values)
+  #
+  # # Exact Kernel SHAP:
+  # #  [[-1.19621609 -1.24184808 -0.9567848   3.87942037 -0.33825     0.54562519]
+  # #  [-1.64922699 -1.20770105 -1.18388581  4.54321217 -0.33795    -0.41082395]]
+  # # Exact (Permutation) SHAP:
+  # #  [[-1.19621609 -1.24184808 -0.9567848   3.87942037 -0.33825     0.54562519]
+  # #  [-1.64922699 -1.20770105 -1.18388581  4.54321217 -0.33795    -0.41082395]]
+
+  expected <- rbind(
+    c(-1.19621609, -1.24184808, -0.9567848, 3.87942037, -0.33825, 0.54562519),
+    c(-1.64922699, -1.20770105, -1.18388581, 4.54321217, -0.33795, -0.41082395)
+  )
+
+  n <- 100
+
+  X <- data.frame(
+    x1 = seq(1:n) / 100,
+    x2 = log(1:n),
+    x3 = sqrt(1:n),
+    x4 = sin(1:n),
+    x5 = (seq(1:n) / 100)^2,
+    x6 = cos(1:n)
+  )
+
+  pf <- function(model, newdata) {
+    x <- newdata
+    x[, 1] * x[, 2] * x[, 3] * x[, 4] + x[, 5] + x[, 6]
+  }
+  ks <- kernelshap(pf, head(X, 2), bg_X = X, pred_fun = pf, verbose = FALSE)
+  expect_equal(unname(ks$S), expected)
+
+  ps <- permshap(pf, head(X, 2), bg_X = X, pred_fun = pf, verbose = FALSE)
+  expect_equal(unname(ps$S), expected)
+
+  # Sampling versions of KernelSHAP is quite close
+  set.seed(1)
+  ksh2 <- kernelshap(
+    pf,
+    head(X, 1),
+    bg_X = X,
+    pred_fun = pf,
+    hybrid_degree = 2,
+    exact = FALSE,
+    m = 1000,
+    max_iter = 100, ,
+    tol = 0.001,
+    verbose = FALSE
+  )
+  expect_equal(
+    c(ksh2$S),
+    c(-1.194878, -1.24747, -0.9596389, 3.883523, -0.3349787, 0.5453894),
+    tolerance = 1e-4
+  )
+
+  set.seed(1)
+  ksh1 <- kernelshap(
+    pf,
+    head(X, 1),
+    bg_X = X,
+    pred_fun = pf,
+    hybrid_degree = 1,
+    exact = FALSE,
+    m = 1000,
+    max_iter = 1000,
+    tol = 0.001,
+    verbose = FALSE
+  )
+  expect_equal(
+    c(ksh1$S),
+    c(-1.199874, -1.23913, -0.9575389, 3.884381, -0.3451588, 0.5492675),
+    tolerance = 1e-4
+  )
+
+  set.seed(1)
+  ksh0 <- suppressWarnings(
+    kernelshap(
+      pf,
+      head(X, 1),
+      bg_X = X,
+      pred_fun = pf,
+      hybrid_degree = 0,
+      exact = FALSE,
+      m = 10000,
+      max_iter = 10000,
+      tol = 0.002,
+      verbose = FALSE
+    )
+  )
+  expect_equal(
+    c(ksh0$S),
+    c(-1.191228, -1.235814, -0.9362117, 3.849839, -0.3371862, 0.5425477),
+    tolerance = 1e-4
+  )
+})

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -217,7 +217,7 @@ test_that("kernelshap works for large p (hybrid case)", {
 test_that("kernelshap and permshap work for models with high-order interactions", {
   # Expected: Python output
   # import numpy as np
-  # import shap 0.47.2
+  # import shap # 0.47.2
   #
   # X = np.array(
   #   [

--- a/tests/testthat/test-kernelshap-utils.R
+++ b/tests/testthat/test-kernelshap-utils.R
@@ -1,11 +1,13 @@
 test_that("sum of kernel weights is 1", {
   for (p in 2:10) {
-    expect_equal(sum(kernel_weights(p)), 1.0)
+    expect_equal(sum(kernel_weights(p, per_coalition_size = FALSE)), 1.0)
+    expect_equal(sum(kernel_weights(p, per_coalition_size = TRUE)), 1.0)
   }
 })
 
 test_that("Sum of kernel weights is 1, even for subset of domain", {
-  expect_equal(sum(kernel_weights(10L, S = 2:5)), 1.0)
+  expect_equal(sum(kernel_weights(10L, S = 2:5, per_coalition_size = FALSE)), 1.0)
+  expect_equal(sum(kernel_weights(10L, S = 2:5, per_coalition_size = TRUE)), 1.0)
 })
 
 p <- 10L
@@ -102,6 +104,17 @@ test_that("hybrid weights sum to 1 for different p and degree 2", {
       m = 100L, deg = deg, feature_names = LETTERS[1:p]
     )
     expect_equal(sum(pa$w) + sum(sa$w), 1L)
+  }
+})
+
+test_that("sampling input A is comparable from exact input", {
+  set.seed(1)
+
+  for (p in 2:6) {
+    feature_names <- LETTERS[1:p]
+    pa <- input_exact(p, feature_names)
+    sa <- input_sampling(p, m = 100000L, deg = 0, feature_names = feature_names)
+    expect_true(all(abs(pa$A - sa$A) < 0.01))
   }
 })
 


### PR DESCRIPTION
With input from Mario Wuethrich and Ian Covert and his [repo](https://github.com/iancovert/shapley-regression), we have fixed a bug in how `kernelshap()` calculates Kernel weights. 

- The differences caused by this are typically very small, see the first example below.
- Models with interactions of order up to two have been unaffected.
- The PR comes with unit tests that compares a model with high order interactions against Python's "shap".
- Exact Kernel SHAP now provides identical results to exact permutation SHAP.
- Sampling versions of Kernel SHAP converge to exact versions when setting a small tolerance.

Ping @dswatson : Note that the calculation of the exact A matrix in Covert-Lee is actually correct. We were mislead by wrong weights back then.

Ping @wueth

### The resulting SHAP values were only slightly off

First example in the readme (random forest):

```r
# Before the fix

#       log_carat     clarity       color        cut
# [1,]  1.1911791  0.0900462 -0.13531648 0.001845958
# [2,] -0.4927482 -0.1168517  0.09815062 0.028255442

# After the fix

(ks <- kernelshap(fit, X, bg_X = bg_X))

      log_carat     clarity       color         cut
[1,]  1.1913247  0.09005467 -0.13430720 0.000682593
[2,] -0.4931989 -0.11724773  0.09868921 0.028563613

# Now equal to permutation SHAP
(ps <- permshap(fit, X, bg_X = bg_X))

      log_carat     clarity       color         cut
[1,]  1.1913247  0.09005467 -0.13430720 0.000682593
[2,] -0.4931989 -0.11724773  0.09868921 0.028563613
```

### Comparison with Python's "shap"

Now part of the unit tests.

#### Python

```py
import numpy as np
import shap  # 0.47.2

X = np.array(
    [
        np.arange(1, 101) / 100,
        np.log(np.arange(1, 101)),
        np.sqrt(np.arange(1, 101)),
        np.sin(np.arange(1, 101)),
        (np.arange(1, 101) / 100) ** 2,
        np.cos(np.arange(1, 101)),
    ]
).T


def predict(X):
    return X[:, 0] * X[:, 1] * X[:, 2] * X[:, 3] + X[:, 4] + X[:, 5]


ks = shap.explainers.Kernel(predict, X, nsamples=10000)
es = shap.explainers.Exact(predict, X)

print("Exact Kernel SHAP:\n", ks(X[0:2]).values)
print("Exact (Permutation) SHAP:\n", es(X[0:2]).values)

# Exact Kernel SHAP:
#  [[-1.19621609 -1.24184808 -0.9567848   3.87942037 -0.33825     0.54562519]
#  [-1.64922699 -1.20770105 -1.18388581  4.54321217 -0.33795    -0.41082395]]
# Exact (Permutation) SHAP:
#  [[-1.19621609 -1.24184808 -0.9567848   3.87942037 -0.33825     0.54562519]
#  [-1.64922699 -1.20770105 -1.18388581  4.54321217 -0.33795    -0.41082395]]
```

#### R
```r
n <- 100

X <- data.frame(
  x1 = seq(1:n) / 100,
  x2 = log(1:n),
  x3 = sqrt(1:n),
  x4 = sin(1:n),
  x5 = (seq(1:n) / 100)^2,
  x6 = cos(1:n)
)

pf <- function(model, newdata) {
  x <- newdata
  x[, 1] * x[, 2] * x[, 3] * x[, 4] + x[, 5] + x[, 6]
}
(ks <- kernelshap(pf, head(X, 2), bg_X = X, pred_fun = pf))
#             x1        x2         x3       x4       x5         x6
# [1,] -1.196216 -1.241848 -0.9567848 3.879420 -0.33825  0.5456252
# [2,] -1.649227 -1.207701 -1.1838858 4.543212 -0.33795 -0.4108240

(ps <- permshap(pf, head(X, 2), bg_X = X, pred_fun = pf))
#             x1        x2         x3       x4       x5         x6
# [1,] -1.196216 -1.241848 -0.9567848 3.879420 -0.33825  0.5456252
# [2,] -1.649227 -1.207701 -1.1838858 4.543212 -0.33795 -0.4108240
```